### PR TITLE
Remove charset rule from CSS

### DIFF
--- a/src/assets/scss/font-specimen/_font-specimen-base.scss
+++ b/src/assets/scss/font-specimen/_font-specimen-base.scss
@@ -1,5 +1,3 @@
-@charset "UTF-8";
-
 $content-max: 64rem;
 $gutter: 2rem;
 

--- a/src/assets/scss/global/_base.scss
+++ b/src/assets/scss/global/_base.scss
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 :root {
 	// Define some contextual colour variables
 	--ctx-color: var(--t-text-color);


### PR DESCRIPTION
Legacy code that is no longer needed for CSS, thanks @MrHBS for pointing it out!